### PR TITLE
Version 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [v2.0.0] - WebForms API v1.1.0-1.0.4 - 2024-11-20
+### Changed
+- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
+- Updated the SDK release version.
+- Model classes are now serializable.
+- Resolved an issue where setting a default SSL socket for the entire JVM caused unintended side effects.
+- Fixed a memory leak related to the class loader.
+- Addressed dependency vulnerabilities in the following libraries:
+  - bcprov-jdk18on updated to version 1.78.1
+  - com.fasterxml.jackson.core updated to version 2.17.1
+  - org.json updated to version 20240303
+  - jersey updated to version 3.1.6
+- Modified the default basePath to DEMO_REST_BASEPATH.
+
+### Breaking changes
+- Deprecation of OLTU library: The OLTU library for handling OAuth is no longer used.
+### Other Changes
+- Upgradation of OWASP for vulnerability check of dependencies.
+
+## Important Action Required
+- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
+
 ## [v2.0.0-RC1] - WebForms API v1.1.0-1.0.4 - 2024-09-24
 ### Changed
 - Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This client SDK is provided as open source, which enables you to customize its f
     <dependency>
       <groupId>com.docusign</groupId>
       <artifactId>docusign-webforms-java</artifactId>
-      <version>2.0.0-RC1</version>
+      <version>2.0.0</version>
     </dependency>
     ```
 8. If your project is still open, restart Eclipse.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>docusign-webforms-java</artifactId>
     <packaging>jar</packaging>
     <name>docusign-webforms-java</name>
-    <version>2.0.0-RC1</version>
+    <version>2.0.0</version>
     <url>https://developers.docusign.com</url>
     <description>The Docusign NuGet package makes integrating Docusign into your apps and websites a super fast and painless process. The library is open sourced on GitHub, look for the docusign-webforms-csharp-client repository.</description>
 

--- a/src/main/java/com/docusign/webforms/client/ApiClient.java
+++ b/src/main/java/com/docusign/webforms/client/ApiClient.java
@@ -93,7 +93,7 @@ public class ApiClient {
     String javaVersion = System.getProperty("java.version");
 
     // Set default User-Agent.
-    setUserAgent("Swagger-Codegen/1.1.0/2.0.0-RC1/Java/" + javaVersion);
+    setUserAgent("Swagger-Codegen/1.1.0/2.0.0/Java/" + javaVersion);
 
     // Setup authentications (key: authentication name, value: authentication).
     authentications = new HashMap<String, Authentication>();


### PR DESCRIPTION
### Changed
- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
- Updated the SDK release version.
- Model classes are now serializable.
- Resolved an issue where setting a default SSL socket for the entire JVM caused unintended side effects.
- Fixed a memory leak related to the class loader.
- Addressed dependency vulnerabilities in the following libraries:
  - bcprov-jdk18on updated to version 1.78.1
  - com.fasterxml.jackson.core updated to version 2.17.1
  - org.json updated to version 20240303
  - jersey updated to version 3.1.6
- Modified the default basePath to DEMO_REST_BASEPATH.

### Breaking changes
- Deprecation of OLTU library: The OLTU library for handling OAuth is no longer used.
### Other Changes
- Upgradation of OWASP for vulnerability check of dependencies.

## Important Action Required
- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
